### PR TITLE
refactor: User 모듈 전반 리팩토링 및 응답 구조/계층 설계 개선

### DIFF
--- a/console-client/cli.js
+++ b/console-client/cli.js
@@ -174,9 +174,11 @@ async function doLogin() {
       username, 
       password 
     });
-    tokens.accessToken  = res.data.accessToken;
-    tokens.refreshToken = res.data.refreshToken;
+
+    tokens.accessToken  = res.data.data.accessToken;
+    tokens.refreshToken = res.data.data.refreshToken;
     console.log('로그인 성공');
+
 }
 
 /**
@@ -216,7 +218,7 @@ async function doGetMyInfo() {
     const res = await client.get(API.getMyInfo, {
       headers: { Authorization: `Bearer ${tokens.accessToken}` }
     });
-    console.log('내 정보:', res.data);
+    console.log('내 정보:', res.data.data);
 }
 
 async function doUpdateMyInfo() {
@@ -229,7 +231,7 @@ async function doUpdateMyInfo() {
       { name, phone, email },
       { headers: { Authorization: `Bearer ${tokens.accessToken}` } }
     );
-    console.log('수정된 정보:', res.data);
+    console.log('수정된 정보:', res.data.data);
 }
 
 async function doChangePW() {
@@ -253,7 +255,7 @@ async function doRefresh() {
       API.refresh, null,
       { headers: { Authorization: `Bearer ${tokens.refreshToken}` } }
     );
-    tokens.accessToken = res.data.accessToken;
+    tokens.accessToken = res.data.data.accessToken;
     console.log('⟳ 액세스 토큰 재발급 완료');
 }
 
@@ -278,7 +280,7 @@ async function doMatching() {
         headers: { Authorization: `Bearer ${tokens.accessToken}` }
       });
 
-      const data = res.data;
+      const data = res.data.data;
       if (data.status === 'matched') {
         console.log(`✅ 매칭 완료! 채팅방 ID: ${data.roomId}`);
         await startChat(data.roomId, tokens.accessToken, rl);

--- a/src/main/java/com/example/demo/common/ApiResponse.java
+++ b/src/main/java/com/example/demo/common/ApiResponse.java
@@ -1,0 +1,64 @@
+package com.example.demo.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final String    message;
+    private final T         data;
+
+
+    private ApiResponse(String message, T data) {
+        this.message = message;
+        this.data = data;
+    }
+
+    /** 메시지 + 데이터 응답 생성 */
+    private static <T> ApiResponse<T> of(String message, T data) {
+        return new ApiResponse<>(message, data);
+    }
+
+    /** 메시지만 있는 응답 생성 (data = null) */ 
+    private static <T> ApiResponse<T> messageOnly(String message) {
+        return new ApiResponse<>(message, null);
+    }
+
+    
+    // ============================
+    // 전역 공통 응답 호출부
+    // ============================
+
+    /**
+     * 일반적인 200 OK 응답 반환
+     * 
+     * 주어진 메시지와 데이터를 포함한 JSON 본문을 생성합니다.
+     */
+    public static <T> ResponseEntity<ApiResponse<T>> ok(String message, T data) {
+        return ResponseEntity.ok(of(message, data));
+    }
+
+    /**
+     * 일반적인 200 OK 응답 반환
+     * 
+     * 메시지만 포함하고 data는 null
+     * 주로 단순 성공 알림(비밀번호 변경 성공 등)
+     */
+    public static ResponseEntity<ApiResponse<Void>> ok(String message) {
+        return ResponseEntity.ok(messageOnly(message));
+    }
+
+    /**
+     * 리소스 생성 성공을 의미하는 201 Created 응답 반환
+     * 
+     * 메시지로 클라이언트에게 성공 안내만, data는 null
+     * 회원가입, 채팅방 생성 등의 기능에 사용
+     */
+    public static ResponseEntity<ApiResponse<Void>> created(String message) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(messageOnly(message));
+    }
+
+}

--- a/src/main/java/com/example/demo/controller/AuthController.java
+++ b/src/main/java/com/example/demo/controller/AuthController.java
@@ -1,10 +1,10 @@
 package com.example.demo.controller;
 
+import com.example.demo.common.ApiResponse;
 import com.example.demo.dto.AccessTokenResponseDto;
 import com.example.demo.dto.AuthRequestDto;
 import com.example.demo.dto.AuthResponseDto;
 import com.example.demo.service.AuthService;
-import com.example.demo.util.JwtUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
@@ -20,47 +20,44 @@ public class AuthController {
 
     private final AuthService authService;
 
-
-    // 로그인 : accessToken, refreshToken 반환
-    @Operation(summary = "사용자 로그인", description = "아이디/비밀번호를 통해 로그인하고 JWT를 반환합니다.")
+    /**
+     * 로그인 : accessToken, refreshToken 반환
+     */ 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponseDto> login(@RequestBody AuthRequestDto authRequestDto) {
+    @Operation(summary = "사용자 로그인", description = "아이디/비밀번호를 통해 로그인하고 JWT를 반환합니다.")
+    public ResponseEntity<ApiResponse<AuthResponseDto>> login(@RequestBody AuthRequestDto authRequestDto) {
 
-        AuthResponseDto tokens = authService.login(authRequestDto);
+        AuthResponseDto authResponseDto = authService.login(authRequestDto);
 
-        return ResponseEntity.ok(tokens);
+        return ApiResponse.ok("로그인 성공", authResponseDto);
     }
 
 
-    // 로그아웃
-    @Operation(summary = "사용자 로그아웃", description = "헤더에서 전달된 refreshToken을 삭제하여 로그아웃 처리합니다.")
+    /**
+     * 로그아웃
+     */
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String bearerToken) {
+    @Operation(summary = "사용자 로그아웃", description = "헤더에서 전달된 refreshToken을 삭제하여 로그아웃 처리합니다.")
+    public ResponseEntity<ApiResponse<Void>> logout(@RequestHeader("Authorization") String token) {
         
-        String refreshToken = JwtUtils.extractTokenFrom(bearerToken);
+        authService.logout(token);
 
-        authService.logout(refreshToken);
-
-        return ResponseEntity.noContent().build();
+        return ApiResponse.ok("로그아웃 성공");
     }
 
 
-    // Access token 재발급
-    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 기반으로 새로운 액세스 토큰을 발급합니다. 헤더 또는 쿠키에서 refreshToken을 전달합니다.")
+    /**
+     * Access token 재발급
+     */
     @PostMapping("/refresh")
-    public ResponseEntity<AccessTokenResponseDto> refreshAccessToken(
-            @RequestHeader(value = "Authorization", required = false) String authorizationHeader, 
-            @CookieValue(name = "refreshToken", required = false) String refreshTokenCookie) {
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 기반으로 새로운 액세스 토큰을 발급합니다. 헤더 또는 쿠키에서 refreshToken을 전달합니다.")
+    public ResponseEntity<ApiResponse<AccessTokenResponseDto>> refreshAccessToken(
+                                        @RequestHeader(value = "Authorization", required = false) String authorizationHeader, 
+                                        @CookieValue(name = "refreshToken", required = false) String refreshTokenCookie) {
      
-        String newAccessToken = authService.refreshAccessToken(authorizationHeader, refreshTokenCookie);
+        AccessTokenResponseDto accessTokenResponseDto = authService.refreshAccessToken(authorizationHeader, refreshTokenCookie);
 
-        log.debug("New access token generated");
-
-        return ResponseEntity.ok(
-            AccessTokenResponseDto.builder()
-                .accessToken(newAccessToken)
-                .build()
-        );        
+        return ApiResponse.ok("액세스 토큰 재발급 성공", accessTokenResponseDto);
     }
 
 }

--- a/src/main/java/com/example/demo/controller/UserController.java
+++ b/src/main/java/com/example/demo/controller/UserController.java
@@ -1,56 +1,88 @@
 package com.example.demo.controller;
 
-import com.example.demo.domain.User;
 import com.example.demo.service.UserService;
-import com.example.demo.dto.UserInfoResponseDto;
 import com.example.demo.security.CustomUserDetails;
-import com.example.demo.dto.SignupRequestDto;
-import com.example.demo.dto.UpdateUserInfoDto;
-import com.example.demo.dto.ChangePasswordRequestDto;
-import lombok.RequiredArgsConstructor;
+import com.example.demo.common.ApiResponse;
+import com.example.demo.dto.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 
 
-@RestController // 이 클래스가 REST API를 처리하는 컨트롤러임을 명시
+@RestController
 @RequestMapping("/api/user") 
-@RequiredArgsConstructor // final field 자동 주입
+@RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
-
-    // 회원가입
+    
+    /**
+     * 유저 회원가입
+     */
     @PostMapping("/signup")
-    public User signup(@RequestBody SignupRequestDto signupRequest) {
-        return userService.signup(signupRequest);
+    @Operation(summary = "사용자 회원가입", description = "회원가입 요청 정보를 받아 새 사용자를 등록합니다.")
+    public ResponseEntity<ApiResponse<Void>> signup(@RequestBody SignupRequestDto signupRequest) {
+
+        userService.signup(signupRequest);
+
+        return ApiResponse.created("회원가입이 성공적으로 완료되었습니다.");
     }
     
-    // 내 정보 조회
+
+    /**
+     * 내 정보 조회
+     */
     @GetMapping("/me")
-    public UserInfoResponseDto getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        return userService.getMyInfoByUsername(userDetails.getUsername());
+    @Operation(summary = "사용자 정보 조회", description = "현재 로그인한 사용자의 상세 정보를 반환합니다.")
+    public ResponseEntity<ApiResponse<UserInfoResponseDto>> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        UserInfoResponseDto userInfoResponseDtp = userService.getMyInfoByUsername(userDetails.getUsername());
+
+        return ApiResponse.ok("내 정보 조회 성공", userInfoResponseDtp);
     }
 
-    // 내 정보 수정
+    
+
+    /**
+     * 내 정보 수정
+     */
     @PutMapping("/me")
-    public UserInfoResponseDto updateMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                            @RequestBody UpdateUserInfoDto updateUserInfoDto) {
-        return userService.updateUserInfo(userDetails.getUsername(), updateUserInfoDto);
+    @Operation(summary = "사용자 정보 수정", description = "로그인한 사용자의 프로필 정보를 수정합니다.")
+    public ResponseEntity<ApiResponse<UserInfoResponseDto>> updateMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                         @RequestBody UpdateUserInfoDto updateUserInfoDto) {
+
+        UserInfoResponseDto userInfoResponseDto = userService.updateUserInfo(userDetails.getUsername(), updateUserInfoDto);
+
+        return ApiResponse.ok("내 정보 수정 완료", userInfoResponseDto);
     }
 
-    // 비밀번호 변경
+
+    /**
+     * 비밀번호 변경
+     */
     @PutMapping("/password")
-    public ResponseEntity<String> changePassword(@AuthenticationPrincipal CustomUserDetails userDetails, 
-                                                 @RequestBody ChangePasswordRequestDto changePasswordRequestDto) {
+    @Operation(summary = "사용자 비밀번호 변경", description = "현재 비밀번호와 새로운 비밀번호를 입력받아 비밀번호를 변경합니다.")
+    public ResponseEntity<ApiResponse<Void>> changePassword(@AuthenticationPrincipal CustomUserDetails userDetails, 
+                                                            @RequestBody ChangePasswordRequestDto changePasswordRequestDto) {
+
         userService.changePassword(userDetails.getUsername(), changePasswordRequestDto);
-        return ResponseEntity.ok("Password changed successfully");
+
+        return ApiResponse.ok("비밀번호가 성공적으로 변경되었습니다.");                           
     }
 
-    // 회원탈퇴
+
+    /**
+     * 회원탈퇴
+     */
     @DeleteMapping("/withdraw")
-    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    @Operation(summary = "사용자 회원탈퇴", description = "로그인한 사용자의 계정을 삭제합니다. 이 작업은 되돌릴 수 없습니다.")
+    public ResponseEntity<ApiResponse<Void>> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
         userService.withdraw(userDetails.getUsername());
-        return ResponseEntity.noContent().build();
+
+        return ApiResponse.ok("회원 탈퇴가 완료되었습니다");                      
     }
+
 }

--- a/src/main/java/com/example/demo/dto/AccessTokenResponseDto.java
+++ b/src/main/java/com/example/demo/dto/AccessTokenResponseDto.java
@@ -10,5 +10,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class AccessTokenResponseDto {
+
     private String accessToken;
+
+    public static AccessTokenResponseDto of(String accessToken) {
+        return AccessTokenResponseDto.builder()
+            .accessToken(accessToken)
+            .build();
+    }
 }

--- a/src/main/java/com/example/demo/dto/AuthResponseDto.java
+++ b/src/main/java/com/example/demo/dto/AuthResponseDto.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-// 인증 응답 데이터
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,4 +12,12 @@ import lombok.NoArgsConstructor;
 public class AuthResponseDto {
     private String accessToken;
     private String refreshToken;
+
+    public static AuthResponseDto of(String accessToken, String refreshToken) {
+        return AuthResponseDto.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .build();
+    }
+
 }

--- a/src/main/java/com/example/demo/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/demo/dto/UserInfoResponseDto.java
@@ -1,16 +1,24 @@
 package com.example.demo.dto;
 
-import lombok.AllArgsConstructor;
+import com.example.demo.domain.User;
 import lombok.Builder;
 import lombok.Getter;
-//import lombok.Data;
 
 @Getter
 @Builder
-@AllArgsConstructor
 public class UserInfoResponseDto {
+
     private String username;
     private String name;
     private String phone;
     private String email;
+
+     public static UserInfoResponseDto from(User user) {
+        return UserInfoResponseDto.builder()
+            .username(user.getUsername())
+            .name(user.getName())
+            .phone(user.getPhone())
+            .email(user.getEmail())
+            .build();
+     }
 }

--- a/src/main/java/com/example/demo/service/AuthService.java
+++ b/src/main/java/com/example/demo/service/AuthService.java
@@ -1,10 +1,12 @@
 package com.example.demo.service;
 
+import com.example.demo.dto.AccessTokenResponseDto;
 import com.example.demo.dto.AuthRequestDto;
 import com.example.demo.dto.AuthResponseDto;
 
 /**
- * 인증 관련 서비스 인터페이스.
+ * 인증 관련 서비스 인터페이스
+ * 
  * 로그인, 로그아웃, 액세스 토큰 재발급 기능 정의.
  */
 public interface AuthService {
@@ -14,10 +16,10 @@ public interface AuthService {
 
         
     /** 사용자 로그아웃 처리 */
-    void logout(String refreshToken);
+    void logout(String token);
 
 
     /** 리프레시 토큰을 이용한 액세스 토큰 재발급 */
-    String refreshAccessToken(String authorizationHeader, String refreshTokenCookie);
+    AccessTokenResponseDto refreshAccessToken(String authorizationHeader, String refreshTokenCookie);
  
 }

--- a/src/main/java/com/example/demo/service/UserService.java
+++ b/src/main/java/com/example/demo/service/UserService.java
@@ -1,156 +1,34 @@
 package com.example.demo.service;
 
-import com.example.demo.domain.RefreshToken;
-import com.example.demo.domain.User;
-import com.example.demo.repository.RefreshTokenRepository;
-import com.example.demo.repository.UserRepository;
 import com.example.demo.dto.ChangePasswordRequestDto;
 import com.example.demo.dto.SignupRequestDto;
-import com.example.demo.dto.UserInfoResponseDto;
 import com.example.demo.dto.UpdateUserInfoDto;
-//import com.example.demo.dto.ChangePasswordRequestDto;
-import org.springframework.http.HttpStatus;
-import com.example.demo.util.JwtUtils;
+import com.example.demo.dto.UserInfoResponseDto;
 
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
+/**
+ * 회원 정보 관련 인터페이스
+ * 
+ * 회원가입, 내 정보 조회, 내 정보 수정, 비밀번호 변경, 회원탈퇴 기능 정의
+ */
+public interface UserService {
 
-@Service // 비즈니스 로직을 처리하는 서비스 계층
-@Transactional
-@RequiredArgsConstructor // final로 선언된 필드를 자동으로 생성자 주입
-public class UserService {
-    private final UserRepository userRepository;
-    private final RefreshTokenRepository rfTokenRepo;
-    private final JwtUtils jwtUtil;
-    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    /** 회원 가입 : 회원 정보 등록 */
+    void signup(SignupRequestDto signupRequestDto);
 
-    // signup
-    public User signup(SignupRequestDto signupRequestDto) {
-        if(userRepository.findByUsername(signupRequestDto.getUsername()).isPresent()) {
-            throw new RuntimeException("이미 존재하는 사용자입니다.");
-        }
 
-        String encodedPasswowrd = passwordEncoder.encode(signupRequestDto.getPassword());
+    /** 회원 정보 조회 */
+    UserInfoResponseDto getMyInfoByUsername(String username);
 
-        User newUser = User.builder()
-            .username(signupRequestDto.getUsername())
-            .password(encodedPasswowrd)
-            .name(signupRequestDto.getName())
-            .phone(signupRequestDto.getPhone())
-            .email(signupRequestDto.getEmail())
-            .role("ROLE_USER") // Default
-            .build();
 
-        return userRepository.save(newUser);
-    }
+    /** 회원 정보 수정 */
+    UserInfoResponseDto updateUserInfo(String username, UpdateUserInfoDto updateUserInfoDto);
 
-    // getMyInfo
-    public UserInfoResponseDto getMyInfoByUsername(String username) {
-        User user = userRepository.findByUsername(username)
-                    .orElseThrow(()-> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-        return UserInfoResponseDto.builder()
-            .username(user.getUsername())
-            .name(user.getName())
-            .phone(user.getPhone())
-            .email(user.getEmail())
-            .build();
-    }
-    
-    // updateMyInfo
-    public UserInfoResponseDto updateUserInfo(String username, UpdateUserInfoDto updateUserInfoDto) {
-        User user = userRepository.findByUsername(username)
-            .orElseThrow(()-> new RuntimeException("사용자를 찾을 수 없습니다."));
-            user.setName(updateUserInfoDto.getName());
-            user.setPhone(updateUserInfoDto.getPhone());
-            user.setEmail(updateUserInfoDto.getEmail());
+     /** 회원 비밀번호 변경 */
+    void changePassword(String username, ChangePasswordRequestDto changePasswordRequestDto);
 
-            User saved = userRepository.save(user);
 
-            return UserInfoResponseDto.builder()
-                .username(saved.getUsername())
-                .name(saved.getName())
-                .phone(saved.getPhone())
-                .email(saved.getEmail())
-                .build();
-    }
+    /** 회원 탈퇴 */
+    void withdraw(String username);
 
-    // changePassword
-    public void changePassword(String username, ChangePasswordRequestDto changePasswordRequestDto) {
-        User user = userRepository.findByUsername(username)
-            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
-        
-        // 현재 비밀번호 검증
-        if(!passwordEncoder.matches(changePasswordRequestDto.getOldPassword(), user.getPassword())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,"현재 비밀번호가 일치하지 않습니다.");
-        }
-
-        // 새 비밀번호 암호화 후 저장
-        String encodedNew = passwordEncoder.encode(changePasswordRequestDto.getNewPassword());
-        user.setPassword(encodedNew);
-        userRepository.save(user);
-    }
-
-    /**
-     * 회원 탈퇴: 
-     * 1) 해당 사용자의 모든 리프레시 토큰을 삭제하고,
-     * 2) 사용자 엔티티를 삭제합니다.
-     *
-     * username 탈퇴할 사용자의 아이디
-     */
-    public void withdraw(String username) {
-        // 1) 해당 사용자의 리프레시 토큰 전부 삭제
-        rfTokenRepo.deleteAllByUsername(username);
-
-        // 2) 사용자 엔티티 삭제
-        User user = userRepository.findByUsername(username)
-            .orElseThrow(() -> new ResponseStatusException(
-                HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
-        userRepository.delete(user);
-    }
 }
-
-    // login
-    // rawPassword(평문)와 BCrpytPasswordEncoder를 사용하여 암호화한 비밀번호를 비교하는 방식
-    /*
-    public String login(String username, String rawPassword) {
-        User user = userRepository.findByUsername(username)
-            .orElseThrow(()-> new RuntimeException("사용자를 찾을 수 없습니다."));
-
-        if(!passwordEncoder.matches(rawPassword, user.getPassword())) {
-            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
-        }
-
-        return jwtUtil.generateAccessToken(username);
-    }
-    */
-
-    // logout
-    // 로그아웃 처리 : 전잘된 JWT 토큰을 블랙리스트에 등록하고 남은 만료 기간 동안 재사용을 막는다.
-    /*
-    public void logout(String token) {
-        // 토큰이 유효한지 파싱해보고 남은 TTL을 계산
-        long expiresAt = jwtUtil.getExpiration(token);
-        long now  = System.currentTimeMillis();
-        long ttlMillis = Math.max(0, expiresAt - now);
-
-        // Redis나 DB에 (token, 블랙리스트 표시) 형태로 저장
-        blacklistRepo.add(token, ttlMillis);
-    }
-
-    public void deleteRefreshToken(String deleteRefreshToken) {
-        refreshTokenRepo.deleteById(refreshToken);
-    }
-    */
-
-
-    // 내 정보 조회(admin전용 userId 기준으로 search)
-    /*
-    public User getMyInfo(Long userId) {
-        return userRepository.findById(userId)
-            .orElseThrow(()-> new RuntimeException("사용자를 찾을 수 없습니다."));
-    }
-    */

--- a/src/main/java/com/example/demo/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/AuthServiceImpl.java
@@ -3,6 +3,7 @@ import com.example.demo.service.AuthService;
 
 import com.example.demo.domain.RefreshToken;
 import com.example.demo.domain.User;
+import com.example.demo.dto.AccessTokenResponseDto;
 import com.example.demo.dto.AuthRequestDto;
 import com.example.demo.dto.AuthResponseDto;
 import com.example.demo.exception.CustomException;
@@ -55,20 +56,22 @@ public class AuthServiceImpl implements AuthService {
             .build();
             refreshTokenRepository.save(rt);
 
-        return AuthResponseDto.builder()
-            .accessToken(accessToken)
-            .refreshToken(refreshToken)
-            .build();
+        // 응답 DTO 반환
+        return AuthResponseDto.of(accessToken, refreshToken);
     }
 
     /**
      * 사용자 로그아웃 처리
      * 
-     * 전달받은 리프레시 토큰이 DB에 존재하면 삭제
+     * 전달받은 리프레시 토큰이 유효하고 DB에 존재하면 삭제
      */
     @Override
-    public void logout(String refreshToken) {
+    public void logout(String token) {
 
+        // 원문 token 문자열 파싱(bearer token 값만 받음)
+        String refreshToken = JwtUtils.extractTokenFrom(token); 
+
+        // 토큰 존재하면 삭제
         refreshTokenRepository.findByToken(refreshToken).ifPresent(refreshTokenRepository::delete);
     }
 
@@ -79,7 +82,7 @@ public class AuthServiceImpl implements AuthService {
      * 유효성을 검사한 후 새 액세스 토큰을 발급
      */
     @Override
-    public String refreshAccessToken(String authorizationHeader, String refreshTokenCookie) {
+    public AccessTokenResponseDto refreshAccessToken(String authorizationHeader, String refreshTokenCookie) {
 
         // JwtUtils를 통해 validation 검사 및 토큰 추출
         String refreshToken = JwtUtils.extractTokenFromHeaderOrCookie(authorizationHeader, refreshTokenCookie);
@@ -91,7 +94,9 @@ public class AuthServiceImpl implements AuthService {
         // 만료된 Refresh Token이면 DB에서 삭제, 재로그인 필요
         validateTokenExpiry(rt);
 
-        return jwtUtils.generateAccessToken(rt.getUsername());
+        // 응답 DTO 반환
+        String newAccessToken = jwtUtils.generateAccessToken(rt.getUsername());
+        return AccessTokenResponseDto.of(newAccessToken);
     }
 
 

--- a/src/main/java/com/example/demo/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/demo/service/impl/UserServiceImpl.java
@@ -1,0 +1,163 @@
+package com.example.demo.service.impl;
+
+import com.example.demo.service.UserService;
+import com.example.demo.domain.User;
+import com.example.demo.repository.RefreshTokenRepository;
+import com.example.demo.repository.UserRepository;
+import com.example.demo.dto.*;
+import com.example.demo.exception.CustomException;
+import com.example.demo.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository            userRepository;
+    private final RefreshTokenRepository    rfTokenRepo;
+    private final BCryptPasswordEncoder     passwordEncoder;
+
+
+    /**
+     * 회원 가입
+     * 
+     * 회원가입 정보들을 저장하여 사용자를 회원가입 처리
+     */
+    @Override
+    public void signup(SignupRequestDto signupRequestDto) {
+
+        // 사용자 중복 검사(존재할 시 예외처리)
+        validateDuplicateUsername(signupRequestDto.getUsername());
+
+        // 사용자 원문 비밀번호를 BCrypt 해시 알고리즘으로 암호화
+        String encodedPassword = passwordEncoder.encode(signupRequestDto.getPassword());
+
+        // 회원가입 요청 정보를 바탕으로 User 엔티티 생성
+        User newUser = User.builder()
+            .username(signupRequestDto.getUsername())
+            .password(encodedPassword)
+            .name(signupRequestDto.getName())
+            .phone(signupRequestDto.getPhone())
+            .email(signupRequestDto.getEmail())
+            .role("ROLE_USER") // Default
+            .build();
+
+        // 회원 정보 DB에 저장
+        userRepository.save(newUser);
+    }
+
+    /** 
+     * 회원 정보 조회
+     * 
+     * 사용자 정보를 username 기준으로 조회
+    */
+    @Override
+    public UserInfoResponseDto getMyInfoByUsername(String username) {
+
+        // 사용자 조회(존재하지 않으면 예외처리)
+        User user = findUserOrThrow(username);
+
+        // 응답용 DTO 반환
+        return UserInfoResponseDto.from(user);
+    }
+    
+    /**
+     * 회원 정보 수정
+     * 
+     * 수정 가능한 사용자 정보(이름, 전화번호, 이메일)를 수정
+     */
+    @Override
+    public UserInfoResponseDto updateUserInfo(String username, UpdateUserInfoDto updateUserInfoDto) {
+
+        // 사용자 조회(존재하지 않으면 예외처리)
+        User user = findUserOrThrow(username);
+
+        // 전달받은 정보로 사용자 객체 필드 수정
+        user.setName(updateUserInfoDto.getName());
+        user.setPhone(updateUserInfoDto.getPhone());
+        user.setEmail(updateUserInfoDto.getEmail());
+
+        // 변경 사항 DB에 반영
+        User saved = userRepository.save(user);
+
+        // 응답용 DTO 반환
+        return UserInfoResponseDto.from(saved);
+    }
+
+    /**
+     * 비밀번호 변경
+     * 
+     * 사용자가 입력한 현재 비밀번호 일치 여부 검증 후 새 비밀번호로 변경
+     */
+    @Override
+    public void changePassword(String username, ChangePasswordRequestDto changePasswordRequestDto) {
+
+        // 사용자 조회(존재하지 않으면 예외처리)
+        User user = findUserOrThrow(username);
+        
+        // 현재 비밀번호 검증(불일치 시 예외 처리)
+        if(!passwordEncoder.matches(changePasswordRequestDto.getOldPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_CREDENTIALS);
+        }
+
+        // 새 비밀번호 암호화 후 저장
+        String encodedNew = passwordEncoder.encode(changePasswordRequestDto.getNewPassword());
+        user.setPassword(encodedNew);
+
+        // 변경 사항 DB에 반영
+        userRepository.save(user);
+    }
+
+    /**
+     * 회원 탈퇴
+     * 
+     * 해당 사용자의 모든 리프레시 토큰을 삭제하고,
+     * 사용자 엔티티를 삭제
+     */
+    @Override
+    public void withdraw(String username) {
+
+        // 해당 사용자의 리프레시 토큰 전부 삭제
+        rfTokenRepo.deleteAllByUsername(username);
+
+        // 사용자 조회(존재하지 않으면 예외처리)
+        User user = findUserOrThrow(username);
+
+        // 사용자 엔티티 DB에서 삭제
+        userRepository.delete(user);
+    }
+
+
+// =====================================================
+// Helper Methods
+// =====================================================
+
+    /**
+     * 사용자 조회 및 예외 처리
+     * 
+     * 주어진 username이 DB에 존재하는지 확인 후,
+     * 존재하지 않으면 CustomException 발생시킴
+     */
+    private User findUserOrThrow(String username) {
+        return userRepository.findByUsername(username)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 사용자 중복 확인 및 예외 처리
+     * 
+     * 주어진 username이 이미 존재하는지 확인 후,
+     * 존재할 시 CustomException 발생시킴
+     */
+    private void validateDuplicateUsername(String username) {
+        if (userRepository.findByUsername(username).isPresent()) {
+            throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
+        }
+    }
+
+}


### PR DESCRIPTION
#주요 변경사항

1. UserController 응답 구조 통일
   - 모든 응답을 `ApiResponse<T>`로 감싸서 message + data 구조로 일관화
   - `ResponseEntity<String>` 및 `Void` → `ApiResponse<Void>`로 변경
   - 회원가입 응답은 `201 Created` 상태 코드로 반환되도록 변경
   - Swagger 문서화를 위한 `@Operation` 어노테이션 추가 (summary/description)

2. 서비스 계층 인터페이스 분리
   - 기존 `UserService`를 인터페이스로 분리하고 `UserServiceImpl`에서 구현
   - 각 기능(회원가입, 정보 조회/수정, 탈퇴 등)에 대한 역할 정의 명확화
   - 계층 분리를 통한 DI 용이성 및 테스트 편의성 향상

3. UserServiceImpl 예외 처리 및 응답 개선
   - 중복 사용자 검증 및 사용자 조회 로직을 helper 메서드(`validateDuplicateUsername`, `findUserOrThrow`)로 모듈화
   - `CustomException` + `ErrorCode` 기반 도메인 예외 처리 적용

4. UserInfoResponseDto 리팩토링
   - 응답 Dto 생성 책임을 서비스 → Dto 내부로 이동
   - 정적 팩토리 메서드를 통한 응답 일관성 확보 및 가독성 향상